### PR TITLE
feat: update to match the new 0.15.X schema changes

### DIFF
--- a/models/final/eligibility.sql
+++ b/models/final/eligibility.sql
@@ -173,8 +173,12 @@ with eligibility_unpivot as (
         , cast(eligibility_unpivot.orig_reason_for_entitlement as {{ dbt.type_string() }} ) as original_reason_entitlement_code
         , cast(eligibility_unpivot.dual_status as {{ dbt.type_string() }} ) as dual_status_code
         , cast(eligibility_unpivot.medicare_status as {{ dbt.type_string() }} ) as medicare_status_code
+        , cast(NULL as {{ dbt.type_string() }} ) as name_suffix
         , cast(NULL as {{ dbt.type_string() }} ) as first_name
+        , cast(NULL as {{ dbt.type_string() }} ) as middle_name
         , cast(NULL as {{ dbt.type_string() }} ) as last_name
+        , cast(NULL as {{ dbt.type_string() }} ) as email
+        , cast(NULL as {{ dbt.type_string() }} ) as ethnicity
         , cast(NULL as {{ dbt.type_string() }} ) as social_security_number
         , 'self' as subscriber_relation
         , cast(NULL as {{ dbt.type_string() }} ) as address
@@ -211,8 +215,12 @@ select
     , original_reason_entitlement_code
     , dual_status_code
     , medicare_status_code
+    , name_suffix
     , first_name
+    , middle_name
     , last_name
+    , email
+    , ethnicity
     , social_security_number
     , subscriber_relation
     , address

--- a/packages.yml
+++ b/packages.yml
@@ -2,4 +2,4 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=0.9.2","<1.3.0"]
   - package: tuva-health/the_tuva_project
-    version: [">=0.13.0","<0.14.0"]
+    version: [">=0.15.0","<0.16.0"]


### PR DESCRIPTION
## Description of Changes

- **TUVA version upgraded** to `v0.15`.
- **New fields added** to the `eligibility` model:
  - `name_suffix` → set to `NULL`
  - `middle_name` → set to `NULL`
  - `email` → set to `NULL`
  - `ethnicity` → set to `NULL`

---

## How Has This Been Tested?

- Verified the version upgrade in `packages.yml`.
- Ran the models and confirmed successful build without errors.

## Reviewer Focus

- Validate the **`packages.yml`** changes for the version upgrade.
- Review the **`models/final/eligibility.sql`** changes, specifically the new fields and their mappings.


## Checklist before requesting a review
- [ ]  (Optional) I have recorded a Loom performing a self-review of my code
- [X]  My code follows style guidelines
- [ ]  I have commented my code as necessary
- [ ]  (New models only) I have implemented generic dbt tests to validate primary keys/uniqueness in my model
- [ ]  I have added at least one Github label to this PR

## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
